### PR TITLE
Parent process deletes child from process list every time it exits, r…

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -74,12 +74,15 @@ void sh_run() {
 	if ((pid = fork()) != 0) { // Pai
 		add_proc(pid, tokens[0]);
 		if (fore) {
-			if (fore_cycle(pid)) del_proc(pid);
+			fore_cycle(pid);
+			del_proc(pid);
 		}
 		else kill(pid, SIGTSTP);
 	}
 	else { // Filho
-		execve(tokens[0], tokens, environ);
+		if (execve(tokens[0], tokens, environ)) {
+			printf("Program not found.\n");
+		}
 		exit(errno);
 	}
 }

--- a/temp
+++ b/temp
@@ -1,0 +1,3 @@
+Parent process deletes child from process list every time it exits, regardless of exit code.
+
+I still have no idea what is causing the segfault, but it happens even after running identified programs (like /bin/ls).

--- a/todo.md
+++ b/todo.md
@@ -16,7 +16,7 @@
 
 ## Known Bugs
 - [x] Segfault on empty input
-- [ ] Segfult on unknown input
+- [ ] Segfult after program execution.
 
 ## Sure Would Be Nice To Have These
 - [ ] Transform has_proc() (returns 0 or 1) into proc_index() (returns index of process, -1 if process not there)


### PR DESCRIPTION
…egardless of exit code.

I still have no idea what is causing the segfault, but it happens even after running identified programs (like /bin/ls).